### PR TITLE
Fix crash with Factorio 2.0.33

### DIFF
--- a/prototypes/entity.lua
+++ b/prototypes/entity.lua
@@ -309,7 +309,7 @@ data:extend({
   {
       type = "corpse",
       name = "woodenwall-remnants",
-      icon = "__base__/graphics/icons/wall-remnants.png",
+      icon = "__Wood-Walls__/graphics/wooden-wall/wooden-wall.png",
       icon_size = 32,
       flags = {"placeable-neutral", "not-on-map"},
       subgroup="remnants",


### PR DESCRIPTION
Wube removed __base__/graphics/icons/wall-remnants.png as it was not used by the base game.
See https://forums.factorio.com/viewtopic.php?t=126395